### PR TITLE
[고도화] 엔티티 코드 리펙토링 - equals(), hashcode() 에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/fastcampus/backendboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/backendboard/domain/Article.java
@@ -54,11 +54,11 @@ public class Article extends AuditingField{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id!=null && id.equals(article.id);
+        return this.getId() !=null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/backendboard/domain/Comment.java
+++ b/src/main/java/com/fastcampus/backendboard/domain/Comment.java
@@ -46,11 +46,11 @@ public class Comment extends AuditingField{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Comment comment)) return false;
-        return id!=null && id.equals(comment.id);
+        return this.getId()!=null && this.getId().equals(comment.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/backendboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/backendboard/domain/UserAccount.java
@@ -42,11 +42,11 @@ public class UserAccount extends AuditingField {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId!=null && userId.equals(that.userId);
+        return this.getUserId()!=null && this.getUserId().equals(that.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
이 pr은 엔티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #56 