### PR TITLE
[고도화] 댓글 기능 고도화 - 1차 대댓글: 쿼리 업데이트

### DIFF
--- a/src/main/java/com/fastcampus/backendboard/dto/CommentDto.java
+++ b/src/main/java/com/fastcampus/backendboard/dto/CommentDto.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 public record CommentDto(
         Long id,
         Long articleId,
+        Long parentCommentId,
         String content,
         LocalDateTime createdAt,
         String createdId,
@@ -19,23 +20,29 @@ public record CommentDto(
     public static CommentDto of(
                       Long id,
                       Long articleId,
+                      Long parentCommentId,
                       String content,
                       LocalDateTime createdAt,
                       String createdId,
                       LocalDateTime modifiedAt,
                       String modifiedId,
                       UserAccountDto userAccountDto) {
-        return new CommentDto(id, articleId, content, createdAt, createdId, modifiedAt, modifiedId, userAccountDto);
+        return new CommentDto(id, articleId, parentCommentId, content, createdAt, createdId, modifiedAt, modifiedId, userAccountDto);
     }
 
     public static CommentDto of(Long articleId, String content, UserAccountDto userAccountDto){
-        return new CommentDto(null, articleId, content, null, null, null, null, userAccountDto);
+        return CommentDto.of(articleId, null, content, userAccountDto);
+    }
+
+    public static CommentDto of(Long articleId, Long parentCommentId, String content, UserAccountDto userAccountDto){
+        return CommentDto.of(null, articleId, parentCommentId, content, null, null, null, null, userAccountDto);
     }
 
     public static CommentDto from(Comment entity){
         return new CommentDto(
                 entity.getId(),
                 entity.getArticle().getId(),
+                entity.getParentCommentId(),
                 entity.getContent(),
                 entity.getCreatedAt(),
                 entity.getCreatedId(),

--- a/src/main/java/com/fastcampus/backendboard/dto/request/CommentRequest.java
+++ b/src/main/java/com/fastcampus/backendboard/dto/request/CommentRequest.java
@@ -5,13 +5,18 @@ import com.fastcampus.backendboard.dto.UserAccountDto;
 
 public record CommentRequest(
         Long articleId,
+        Long parentCommentId,
         String content
 ) {
     public static CommentRequest of (Long articleId, String content) {
-        return new CommentRequest(articleId, content);
+        return CommentRequest.of(articleId, null, content);
+    }
+
+    public static CommentRequest of (Long articleId, Long parentCommentId, String content) {
+        return new CommentRequest(articleId, parentCommentId, content);
     }
 
     public CommentDto toDto(UserAccountDto userAccountDto){
-        return CommentDto.of(articleId, content, userAccountDto);
+        return CommentDto.of(articleId, parentCommentId, content, userAccountDto);
     }
 }

--- a/src/main/java/com/fastcampus/backendboard/dto/response/CommentResponse.java
+++ b/src/main/java/com/fastcampus/backendboard/dto/response/CommentResponse.java
@@ -2,18 +2,31 @@ package com.fastcampus.backendboard.dto.response;
 
 import com.fastcampus.backendboard.dto.CommentDto;
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
 
 public record CommentResponse(
         Long id,
+        Long parentCommentId,
         String content,
         LocalDateTime createdAt,
         String email,
         String nickname,
-        String userId
+        String userId,
+        Set<CommentResponse> childComments
 
 ) {
     public static CommentResponse of (Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
-        return new CommentResponse(id, content, createdAt, email, nickname, userId);
+        return CommentResponse.of(id, null, content, createdAt, email, nickname, userId);
+    }
+
+    public static CommentResponse of (Long id, Long parentCommentId, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        Comparator<CommentResponse> childCommentComparator = Comparator
+                .comparing(CommentResponse::createdAt)
+                .thenComparingLong(CommentResponse::id);
+
+        return new CommentResponse(id, parentCommentId, content, createdAt, email, nickname, userId, new TreeSet<>(childCommentComparator));
     }
 
     public static CommentResponse from(CommentDto dto){
@@ -21,13 +34,18 @@ public record CommentResponse(
         if(nickname == null || nickname.isBlank()){
             nickname = dto.userAccountDto().userId();
         }
-        return new CommentResponse(
+        return CommentResponse.of(
                 dto.id(),
+                dto.parentCommentId(),
                 dto.content(),
                 dto.createdAt(),
                 dto.userAccountDto().email(),
                 nickname,
                 dto.userAccountDto().userId()
         );
+    }
+
+    public boolean hasParentComment(){
+        return parentCommentId!=null;
     }
 }

--- a/src/main/java/com/fastcampus/backendboard/service/CommentService.java
+++ b/src/main/java/com/fastcampus/backendboard/service/CommentService.java
@@ -33,7 +33,14 @@ public class CommentService {
         try{
             Article article = articleRepository.getReferenceById(dto.articleId());
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
-            commentRepository.save(dto.toEntity(article, userAccount));
+            Comment comment = dto.toEntity(article, userAccount);
+
+            if(dto.parentCommentId()!=null){
+                Comment parentComment = commentRepository.getReferenceById(dto.parentCommentId());
+                parentComment.addChildComment(comment);
+            }else{
+                commentRepository.save(comment);
+            }
         }catch (EntityNotFoundException e){
             log.warn("Failed Save Comment, Not Found Article or User - {}",e.getLocalizedMessage());
         }

--- a/src/test/java/com/fastcampus/backendboard/controller/CommentControllerTest.java
+++ b/src/test/java/com/fastcampus/backendboard/controller/CommentControllerTest.java
@@ -82,4 +82,28 @@ class CommentControllerTest {
 
         then(commentService).should().deleteComment(commentId,userId);
     }
+
+    @WithUserDetails(value = "test", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[view][POST] Insert Child Comment - 200 OK")
+    @Test
+    public void givenCommentInfoWithParentCommentId_whenRequesting_thenSaveNewChildComment() throws Exception {
+        //Given
+        long articleId = 14L;
+        long parentCommentId = 1L;
+        CommentRequest request = CommentRequest.of(articleId,parentCommentId, "content" );
+        willDoNothing().given(commentService).saveComment(any(CommentDto.class));
+
+        //When&Then
+        mvc.perform(
+                post("/comments/save")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(request))
+                        .with(csrf())
+        )
+        .andExpect(status().is3xxRedirection())
+        .andExpect(view().name("redirect:/articles/"+articleId))
+        .andExpect(redirectedUrl("/articles/"+articleId));
+
+        then(commentService).should().saveComment(any(CommentDto.class));
+    }
 }

--- a/src/test/java/com/fastcampus/backendboard/dto/response/ArticleWithCommentsResponseTest.java
+++ b/src/test/java/com/fastcampus/backendboard/dto/response/ArticleWithCommentsResponseTest.java
@@ -1,0 +1,180 @@
+package com.fastcampus.backendboard.dto.response;
+import com.fastcampus.backendboard.dto.ArticleWithCommentsDto;
+import com.fastcampus.backendboard.dto.CommentDto;
+import com.fastcampus.backendboard.dto.HashtagDto;
+import com.fastcampus.backendboard.dto.UserAccountDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DTO - 댓글을 포함한 게시글 응답 테스트")
+class ArticleWithCommentsResponseTest {
+
+    @DisplayName("자식 댓글이 없는 게시글 + 댓글 dto를 api 응답으로 변환할 때, 댓글을 시간 내림차순 + ID 오름차순으로 정리한다.")
+    @Test
+    void givenArticleWithCommentsDtoWithoutChildComments_whenMapping_thenOrganizesCommentsWithCertainOrder() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Set<CommentDto> articleCommentDtos = Set.of(
+                createCommentDto(1L, null, now),
+                createCommentDto(2L, null, now.plusDays(1L)),
+                createCommentDto(3L, null, now.plusDays(3L)),
+                createCommentDto(4L, null, now),
+                createCommentDto(5L, null, now.plusDays(5L)),
+                createCommentDto(6L, null, now.plusDays(4L)),
+                createCommentDto(7L, null, now.plusDays(2L)),
+                createCommentDto(8L, null, now.plusDays(7L))
+        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        // When
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        // Then
+        assertThat(actual.commentsResponse())
+                .containsExactly(
+                        createCommentResponse(8L, null, now.plusDays(7L)),
+                        createCommentResponse(5L, null, now.plusDays(5L)),
+                        createCommentResponse(6L, null, now.plusDays(4L)),
+                        createCommentResponse(3L, null, now.plusDays(3L)),
+                        createCommentResponse(7L, null, now.plusDays(2L)),
+                        createCommentResponse(2L, null, now.plusDays(1L)),
+                        createCommentResponse(1L, null, now),
+                        createCommentResponse(4L, null, now)
+                );
+    }
+
+    @DisplayName("게시글 + 댓글 dto를 api 응답으로 변환할 때, 댓글 부모 자식 관계를 각각의 규칙으로 정렬하여 정리한다.")
+    @Test
+    void givenArticleWithCommentsDto_whenMapping_thenOrganizesParentAndChildCommentsWithCertainOrders() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Set<CommentDto> commentDtos = Set.of(
+                createCommentDto(1L, null, now),
+                createCommentDto(2L, 1L, now.plusDays(1L)),
+                createCommentDto(3L, 1L, now.plusDays(3L)),
+                createCommentDto(4L, 1L, now),
+                createCommentDto(5L, null, now.plusDays(5L)),
+                createCommentDto(6L, null, now.plusDays(4L)),
+                createCommentDto(7L, 6L, now.plusDays(2L)),
+                createCommentDto(8L, 6L, now.plusDays(7L))
+        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(commentDtos);
+
+        // When
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        // Then
+        assertThat(actual.commentsResponse())
+                .containsExactly(
+                        createCommentResponse(5L, null, now.plusDays(5)),
+                        createCommentResponse(6L, null, now.plusDays(4)),
+                        createCommentResponse(1L, null, now)
+                )
+                .flatExtracting(CommentResponse::childComments)
+                .containsExactly(
+                        createCommentResponse(7L, 6L, now.plusDays(2L)),
+                        createCommentResponse(8L, 6L, now.plusDays(7L)),
+                        createCommentResponse(4L, 1L, now),
+                        createCommentResponse(2L, 1L, now.plusDays(1L)),
+                        createCommentResponse(3L, 1L, now.plusDays(3L))
+                );
+    }
+
+    @DisplayName("게시글 + 댓글 dto를 api 응답으로 변환할 때, 부모 자식 관계 깊이(depth)는 제한이 없다.")
+    @Test
+    void givenArticleWithCommentsDto_whenMapping_thenOrganizesParentAndChildCommentsWithoutDepthLimit() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Set<CommentDto> articleCommentDtos = Set.of(
+                createCommentDto(1L, null, now),
+                createCommentDto(2L, 1L, now.plusDays(1L)),
+                createCommentDto(3L, 2L, now.plusDays(2L)),
+                createCommentDto(4L, 3L, now.plusDays(3L)),
+                createCommentDto(5L, 4L, now.plusDays(4L)),
+                createCommentDto(6L, 5L, now.plusDays(5L)),
+                createCommentDto(7L, 6L, now.plusDays(6L)),
+                createCommentDto(8L, 7L, now.plusDays(7L))
+        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        // When
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        // Then
+        Iterator<CommentResponse> iterator = actual.commentsResponse().iterator();
+        long i = 1L;
+        while (iterator.hasNext()) {
+            CommentResponse articleCommentResponse = iterator.next();
+            assertThat(articleCommentResponse)
+                    .hasFieldOrPropertyWithValue("id", i)
+                    .hasFieldOrPropertyWithValue("parentCommentId", i == 1L ? null : i - 1L)
+                    .hasFieldOrPropertyWithValue("createdAt", now.plusDays(i - 1L));
+
+            iterator = articleCommentResponse.childComments().iterator();
+            i++;
+        }
+    }
+
+
+    private ArticleWithCommentsDto createArticleWithCommentsDto(Set<CommentDto> commentDtos) {
+        return ArticleWithCommentsDto.of(
+                LocalDateTime.now(),
+                "kej",
+                LocalDateTime.now(),
+                "kej",
+                1L,
+                "title",
+                "content",
+                Set.of(HashtagDto.of("java")),
+                createUserAccountDto(),
+                commentDtos
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "kej",
+                "1234",
+                "kej@email.com",
+                "K",
+                "This is memo",
+                LocalDateTime.now(),
+                "kej",
+                LocalDateTime.now(),
+                "kej"
+        );
+    }
+
+    private CommentDto createCommentDto(Long id, Long parentCommentId, LocalDateTime createdAt) {
+        return CommentDto.of(
+                id,
+                1L,
+                parentCommentId,
+                "content "+id,
+                createdAt,
+                "kej",
+                createdAt,
+                "kej",
+                createUserAccountDto()
+        );
+    }
+
+    private CommentResponse createCommentResponse(Long id, Long parentCommentId, LocalDateTime createdAt) {
+        return CommentResponse.of(
+                id,
+                parentCommentId,
+                "content "+id,
+                createdAt,
+                "kej@email.com",
+                "K",
+                "kej"
+        );
+    }
+
+}

--- a/src/test/java/com/fastcampus/backendboard/service/CommentServiceTest.java
+++ b/src/test/java/com/fastcampus/backendboard/service/CommentServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
@@ -41,15 +42,24 @@ class CommentServiceTest {
     void givenArticleId_whenSearchingComments_thenReturnComments() {
         //Given
         Long articleId = 1L;
-        Comment expected = createComment("content");
-        given(commentRepository.findByArticle_Id(articleId)).willReturn(List.of(expected));
+        Comment expectedParentComment = createComment(1L, "parent");
+        Comment expectedChildComment = createComment(2L, "child");
+
+        expectedChildComment.setParentCommentId(expectedParentComment.getId());
+
+        given(commentRepository.findByArticle_Id(articleId)).willReturn(List.of(expectedParentComment,expectedChildComment));
         //When
         List<CommentDto> actual = sut.searchComments(articleId);
 
         //Then
+        assertThat(actual).hasSize(2);
         assertThat(actual)
-                .hasSize(1)
-                .first().hasFieldOrPropertyWithValue("content", expected.getContent());
+                .extracting("id","articleId","parentCommentId","content")
+                .containsExactlyInAnyOrder(
+                        tuple(1L,1L,null,"parent"),
+                        tuple(2L,1L,1L,"child")
+                );
+
         then(commentRepository).should().findByArticle_Id(articleId);
     }
 
@@ -68,6 +78,7 @@ class CommentServiceTest {
         //Then
         then(articleRepository).should().getReferenceById(dto.articleId());
         then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
+        then(commentRepository).should(never()).getReferenceById(anyLong());
         then(commentRepository).should().save(any(Comment.class));
     }
 
@@ -136,9 +147,39 @@ class CommentServiceTest {
         then(commentRepository).should().deleteByIdAndUserAccount_UserId(commentId, userId);
     }
 
+    @DisplayName("When Inserting comment info & parentComment id, Saves Child comment.")
+    @Test
+    void givenParentCommentIdAndCommentInfo_whenSaving_thenSavesChildComment(){
+        ///Given
+        Comment parent = createComment(1L, "parent");
+        CommentDto child = createCommentDto(1L, "child");
+
+        given(articleRepository.getReferenceById(child.articleId())).willReturn(createArticle());
+        given(userAccountRepository.getReferenceById(child.userAccountDto().userId())).willReturn(createUserAccount());
+        given(commentRepository.getReferenceById(child.parentCommentId())).willReturn(parent);
+
+        //When
+        sut.saveComment(child);
+
+        //Then
+        assertThat(child.parentCommentId()).isNotNull();
+        then(articleRepository).should().getReferenceById(child.articleId());
+        then(userAccountRepository).should().getReferenceById(child.userAccountDto().userId());
+        then(commentRepository).should().getReferenceById(child.parentCommentId());
+        then(commentRepository).should(never()).save(any(Comment.class));
+    }
+
     private CommentDto createCommentDto(String content){
+        return createCommentDto(null, content);
+    }
+
+    private CommentDto createCommentDto(Long parentCommentId, String content){
+        return createCommentDto(1L, parentCommentId, content);
+    }
+
+    private CommentDto createCommentDto(Long id, Long parentCommentId, String content){
         return CommentDto.of(
-                1L,1L, content, LocalDateTime.now(),"kej",LocalDateTime.now(),"kej",createUserAccountDto()
+                id,1L, parentCommentId, content, LocalDateTime.now(),"kej",LocalDateTime.now(),"kej",createUserAccountDto()
         );
     }
 
@@ -155,6 +196,15 @@ class CommentServiceTest {
         );
     }
 
+    private Comment createComment(Long id, String content){
+        Comment comment = Comment.of(createUserAccount(),
+                createArticle(),
+                content
+        );
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
+    }
+
     private UserAccount createUserAccount() {
         return UserAccount.of(
                 "kej","1234","kej@email.com","K","this is memo"
@@ -166,6 +216,7 @@ class CommentServiceTest {
                 createUserAccount(), "title", "content"
         );
 
+        ReflectionTestUtils.setField(article, "id", 1L);
         article.addHashtags(Set.of(createHashtag(article)));
         return article;
     }


### PR DESCRIPTION
entity <-> dto 간 변환 로직
댓글 서비스에서 댓글과 대댓글 저장하고 삭제하기
댓글과 대댓글을 DB 데이터로 변환할 때 서로 계층 구조를 만들고 각각 정렬하는 과정을 구현

This closes #67 